### PR TITLE
5 extract history

### DIFF
--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -22,9 +22,14 @@ library(forcats)
 
 ```{r extracting endowment information}
 
+##########################################################
+# ITERATE THROUGH ALL FILES AND ENDOWMENT  VARIABLES
+##########################################################
+
+#' @param filename string containing full path to xml file to be read
+
 ##Based off of Quinn's strategy to extract metadata
-get_endowment <- function(filename, 
-                   include_paths = TRUE) {
+get_endowment <- function(filename) {
   
   # Retrieving the same endowment information for all 
   variables <- c("//Return//ReturnHeader//ReturnTs", 
@@ -125,9 +130,24 @@ get_endowment <- function(filename,
 }
 ```
 
+
 ```{r}
-test_path <- "nycb_fy2020.xml"
-test_output <- get_endowment(test_path)
-#test_output
+##Applying get_endowment to entire output 
+files <- dir( "./ballet_990_released_20230208",
+              full.names = TRUE)
+
+endowment_data <- map_df(files, ~
+                     get_endowment(.x)) 
+
+endowment_datatest <- endowment_data %>%
+  mutate(ReturnTs = as.Date(ReturnTs,
+                              format = "%Y-%m-%d")) %>%
+  mutate(across(2:TermEndowmentBalanceEOYPct,
+                as.numeric)) %>%
+  mutate(across(c(EndowmentsHeldRelatedOrgInd, EndowmentsHeldUnrelatedOrgInd),
+                as.logical)) %>%
+  rename(ReturnDate = ReturnTs)
+  
+saveRDS(all_data, "./data/endowment_data_990.RDS")
 ```
 

--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -140,7 +140,7 @@ endowment_data <- map_df(files, ~
                      get_endowment(.x)) 
 
 ## Adjusting data type
-endowment_datatest <- endowment_data %>%
+endowment_data <- endowment_data %>%
   mutate(ReturnTs = as.Date(ReturnTs,
                               format = "%Y-%m-%d")) %>%
   mutate(across(2:TermEndowmentBalanceEOYPct,
@@ -150,5 +150,23 @@ endowment_datatest <- endowment_data %>%
   rename(ReturnDate = ReturnTs)
   
 saveRDS(all_data, "./data/endowment_data_990.RDS")
+```
+
+```{r}
+##Graphing difference between beginning and end periods
+endowment_data %>%
+  select(ReturnDate, EIN, CYBeginningYearBalanceAmt, CYEndYearBalanceAmt) %>%
+  pivot_longer(cols = c(CYBeginningYearBalanceAmt, CYEndYearBalanceAmt), names_to = "Period", values_to = "Balance") %>%
+  mutate(Period = as.factor(Period)) %>%
+  mutate(Year = substr(ReturnDate, 1, 4)) %>%
+  ggplot(aes(x = Period, y = Balance, group = EIN)) +
+  facet_wrap(~Year) +
+  geom_point(alpha = 0.5) + 
+  geom_line(alpha = 0.5) + 
+  theme_bw() + 
+  theme(axis.text.x = element_text(angle = 35, hjust =1),
+        legend.position = "none") +
+  labs(title = "Comparing Fiscal Year Beginning and End Endowment Totals") +
+  scale_y_continuous(labels = scales::label_dollar())
 ```
 

--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -1,0 +1,133 @@
+---
+title: "Retrieve Endowment Funds"
+author: "Rose Evard"
+date: "`r Sys.Date()`"
+output:
+  rmdformats::readthedown:
+    df_print: paged
+    code_folding: hide
+---
+
+```{r}
+
+library(tidyverse)
+library(xml2)
+library(kableExtra)
+library(lubridate)
+library(forcats)
+
+
+```
+
+
+```{r extracting endowment information}
+
+##Based off of Quinn's strategy to extract metadata
+get_endowment <- function(filename, 
+                   include_paths = TRUE) {
+  
+  # Retrieving the same endowment information for all 
+  variables <- c("//Return//ReturnHeader//ReturnTs", 
+                 "//Return//ReturnHeader//Filer//EIN", 
+                 "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//BeginningYearBalanceAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//ContributionsAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//OtherExpendituresAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//EndYearBalanceAmt",
+                 
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus1YrEndwmtFundGrp//BeginningYearBalanceAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus1YrEndwmtFundGrp//ContributionsAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus1YrEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus1YrEndwmtFundGrp//OtherExpendituresAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus1YrEndwmtFundGrp//EndYearBalanceAmt",
+                
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus2YrEndwmtFundGrp//BeginningYearBalanceAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus2YrEndwmtFundGrp//ContributionsAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus2YrEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus2YrEndwmtFundGrp//OtherExpendituresAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus2YrEndwmtFundGrp//EndYearBalanceAmt",
+                 
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus3YrEndwmtFundGrp//BeginningYearBalanceAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus3YrEndwmtFundGrp//ContributionsAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus3YrEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus3YrEndwmtFundGrp//OtherExpendituresAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus3YrEndwmtFundGrp//EndYearBalanceAmt",
+                 
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus4YrEndwmtFundGrp//BeginningYearBalanceAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus4YrEndwmtFundGrp//ContributionsAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus4YrEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus4YrEndwmtFundGrp//OtherExpendituresAmt",
+                 "//Return//ReturnData//IRS990ScheduleD//CYMinus4YrEndwmtFundGrp//EndYearBalanceAmt",
+                 
+                 "//Return//ReturnData//IRS990ScheduleD//BoardDesignatedBalanceEOYPct",
+                 "//Return//ReturnData//IRS990ScheduleD//PrmnntEndowmentBalanceEOYPct",
+                 "//Return//ReturnData//IRS990ScheduleD//TermEndowmentBalanceEOYPct",
+                 "//Return//ReturnData//IRS990ScheduleD//EndowmentsHeldUnrelatedOrgInd",
+                 "//Return//ReturnData//IRS990ScheduleD//EndowmentsHeldRelatedOrgInd"
+                 )
+  
+  # Column name; order matters, needs to align with retrieval order
+  variables_no_path <- c("ReturnTs", 
+                         "EIN",
+                        "CYBeginningYearBalanceAmt", 
+                        "CYContributionsAmt", 
+                        "CYInvestmentEarningsOrLossesAmt",
+                        "CYOtherExpendituresAmt",
+                        "CYEndYearBalanceAmt",
+                        
+                        "CYM1BeginningYearBalanceAmt", 
+                        "CYM1ContributionsAmt", 
+                        "CYM1InvestmentEarningsOrLossesAmt",
+                        "CYM1OtherExpendituresAmt",
+                        "CYM1EndYearBalanceAmt",
+                        
+                        "CYM2BeginningYearBalanceAmt", 
+                        "CYM2ContributionsAmt", 
+                        "CYM2InvestmentEarningsOrLossesAmt",
+                        "CYM2OtherExpendituresAmt",
+                        "CYM2EndYearBalanceAmt",
+                        
+                        "CYM3BeginningYearBalanceAmt", 
+                        "CYM3ContributionsAmt", 
+                        "CYM3InvestmentEarningsOrLossesAmt",
+                        "CYM3OtherExpendituresAmt",
+                        "CYM3EndYearBalanceAmt",
+                        
+                        "CYM4BeginningYearBalanceAmt", 
+                        "CYM4ContributionsAmt", 
+                        "CYM4InvestmentEarningsOrLossesAmt",
+                        "CYM4OtherExpendituresAmt",
+                        "CYM4EndYearBalanceAmt",
+                        
+                        "BoardDesignatedBalanceEOYPct",
+                        "PrmnntEndowmentBalanceEOYPct",
+                        "TermEndowmentBalanceEOYPct",
+                        "EndowmentsHeldUnrelatedOrgInd",
+                        "EndowmentsHeldRelatedOrgInd"
+                        )
+  
+  xml_file <- read_xml(filename)
+  xml_file <- xml_ns_strip(xml_file)
+  
+  # extract each variable; if it isn't present, put NA 
+  extracted <- map(variables, ~{
+    value <- xml_find_all(
+      xml_file, 
+      xpath =.x)
+    value <- ifelse(length(value) ==0, 
+                    NA, 
+                    xml_text(value)) })
+  
+   names(extracted) <- variables_no_path
+   
+   extracted <- extracted %>%
+     as_tibble()
+}
+```
+
+```{r}
+test_path <- "nycb_fy2020.xml"
+test_output <- get_endowment(test_path)
+#test_output
+```
+

--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -70,7 +70,10 @@ get_endowment <- function(filename) {
                  "//Return//ReturnData//IRS990ScheduleD//PrmnntEndowmentBalanceEOYPct",
                  "//Return//ReturnData//IRS990ScheduleD//TermEndowmentBalanceEOYPct",
                  "//Return//ReturnData//IRS990ScheduleD//EndowmentsHeldUnrelatedOrgInd",
-                 "//Return//ReturnData//IRS990ScheduleD//EndowmentsHeldRelatedOrgInd"
+                 "//Return//ReturnData//IRS990ScheduleD//EndowmentsHeldRelatedOrgInd",
+                 
+                 "//AmendedReturnInd",
+                 "//Return//ReturnHeader//ReturnTypeCd"
                  )
   
   # Column name; order matters, needs to align with retrieval order
@@ -111,7 +114,10 @@ get_endowment <- function(filename) {
                         "PrmnntEndowmentBalanceEOYPct",
                         "TermEndowmentBalanceEOYPct",
                         "EndowmentsHeldUnrelatedOrgInd",
-                        "EndowmentsHeldRelatedOrgInd"
+                        "EndowmentsHeldRelatedOrgInd",
+                        
+                        "AmendedReturnInd",
+                        "ReturnTypeCd"
                         )
   
   xml_file <- read_xml(filename)
@@ -150,15 +156,19 @@ endowment_data <- map_df(files, ~
 
 ## Adjusting data type
 endowment_data <- endowment_data %>%
-  mutate(ReturnTs = as.Date(ReturnTs,
+  mutate(ReturnDate = as.Date(ReturnTs,
                               format = "%Y-%m-%d")) %>%
   mutate(across(CYBeginningYearBalanceAmt:TermEndowmentBalanceEOYPct,
                 as.numeric)) %>%
   mutate(across(c(EndowmentsHeldRelatedOrgInd, EndowmentsHeldUnrelatedOrgInd, DonorRstrOrQuasiEndowmentsInd),
                 ~ifelse(.x == "true" | .x == "1", TRUE, FALSE))) %>%
-  rename(ReturnDate = ReturnTs)
-  
-saveRDS(all_data, "./data/endowment_data_990.RDS")
+  filter(is.na(AmendedReturnInd)) %>% #Filtering out data
+  filter(ReturnTypeCd == "990" | ReturnTypeCd == "990EZ") %>%
+  select(-c(ReturnTypeCd,AmendedReturnInd)) #Removing columns needed for filtering
+```
+
+```{r saving data}
+saveRDS(endowment_data, "./data/endowment_data_990.RDS")
 ```
 
 ```{r}
@@ -180,4 +190,30 @@ endowment_data %>%
 ```
 
 
-## Determining W
+## Determining Which Needed to File Schedule D for Endowment
+
+Not all those that fill out schedule D do so for endowment, so I focused on Question 10 "Did the organization, directly or through a related organization, hold assets in temporarily restricted endowments, permanent endowments, or quasi endowments?  If "yes," complete Schedule D, Part V".  
+
+```{r}
+##Identifying those that DID fill out schedule D for Endowment, as they supplied info in any numeric column
+##Assuming the sum of from cols 4-31 (schedule D finances) is not zero
+fill_d <- endowment_data %>%
+ mutate(FilledSchD = ifelse(rowSums(across(CYBeginningYearBalanceAmt:TermEndowmentBalanceEOYPct), na.rm = TRUE) != 0, TRUE, FALSE)) %>%
+  select(ReturnDate, EIN, DonorRstrOrQuasiEndowmentsInd, FilledSchD)
+
+##Counting those that needed to fill schedule D
+endowment_data %>%
+  group_by(DonorRstrOrQuasiEndowmentsInd) %>%
+  summarize(n = n()) %>%
+  kbl(caption = "Total EINs checked YES on Q10") %>%
+  kable_material()
+
+##Seeing those that DID and or DID NOT need to fill out Schedule D, yet Did or Did Not
+fill_d %>%
+  group_by(DonorRstrOrQuasiEndowmentsInd, FilledSchD) %>%
+  summarize(n = n()) %>%
+  kbl(caption = "990 Q10 answer and If They Filled out Schedule D") %>%
+  kable_material()
+```
+
+> Editor's note: Prior to filtering the data for 990T and amended files, there were ones that marked Q10 as true, approximately 20 of them.  

--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -139,6 +139,7 @@ files <- dir( "./ballet_990_released_20230208",
 endowment_data <- map_df(files, ~
                      get_endowment(.x)) 
 
+## Adjusting data type
 endowment_datatest <- endowment_data %>%
   mutate(ReturnTs = as.Date(ReturnTs,
                               format = "%Y-%m-%d")) %>%

--- a/retrieve_endowment.Rmd
+++ b/retrieve_endowment.Rmd
@@ -20,6 +20,7 @@ library(forcats)
 ```
 
 
+## Extracting Endowments  
 ```{r extracting endowment information}
 
 ##########################################################
@@ -34,6 +35,7 @@ get_endowment <- function(filename) {
   # Retrieving the same endowment information for all 
   variables <- c("//Return//ReturnHeader//ReturnTs", 
                  "//Return//ReturnHeader//Filer//EIN", 
+                 "//Return//ReturnData//IRS990//DonorRstrOrQuasiEndowmentsInd",
                  "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//BeginningYearBalanceAmt",
                  "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//ContributionsAmt",
                  "//Return//ReturnData//IRS990ScheduleD//CYEndwmtFundGrp//InvestmentEarningsOrLossesAmt",
@@ -74,6 +76,7 @@ get_endowment <- function(filename) {
   # Column name; order matters, needs to align with retrieval order
   variables_no_path <- c("ReturnTs", 
                          "EIN",
+                         "DonorRstrOrQuasiEndowmentsInd",
                         "CYBeginningYearBalanceAmt", 
                         "CYContributionsAmt", 
                         "CYInvestmentEarningsOrLossesAmt",
@@ -130,6 +133,12 @@ get_endowment <- function(filename) {
 }
 ```
 
+```{r}
+test_path <- "nycb_fy2020.xml"
+test <- get_endowment(test_path)
+```
+
+> An important question: Does ZERO in a boolean situation mean false or mean NA?  There are cases where 1s and 0s are coded for T/F.
 
 ```{r}
 ##Applying get_endowment to entire output 
@@ -143,10 +152,10 @@ endowment_data <- map_df(files, ~
 endowment_data <- endowment_data %>%
   mutate(ReturnTs = as.Date(ReturnTs,
                               format = "%Y-%m-%d")) %>%
-  mutate(across(2:TermEndowmentBalanceEOYPct,
+  mutate(across(CYBeginningYearBalanceAmt:TermEndowmentBalanceEOYPct,
                 as.numeric)) %>%
-  mutate(across(c(EndowmentsHeldRelatedOrgInd, EndowmentsHeldUnrelatedOrgInd),
-                as.logical)) %>%
+  mutate(across(c(EndowmentsHeldRelatedOrgInd, EndowmentsHeldUnrelatedOrgInd, DonorRstrOrQuasiEndowmentsInd),
+                ~ifelse(.x == "true" | .x == "1", TRUE, FALSE))) %>%
   rename(ReturnDate = ReturnTs)
   
 saveRDS(all_data, "./data/endowment_data_990.RDS")
@@ -170,3 +179,5 @@ endowment_data %>%
   scale_y_continuous(labels = scales::label_dollar())
 ```
 
+
+## Determining W


### PR DESCRIPTION
Pulls in all Endowment information from Schedule D for the filtered endowments, as well as collects whether or not the 990 answered Q10 of the part IV checklist, which indicated the need for the Schedule D to be filled out particularly for endowments.  

This assumes you have the raw data files, but not the filtered or metadata table.

Closes issues #5 and #6 