### PR TITLE
only keep EIN and organization name in the csv

### DIFF
--- a/infrastructure_rmds/load_wrangle_filter_data.Rmd
+++ b/infrastructure_rmds/load_wrangle_filter_data.Rmd
@@ -388,3 +388,14 @@ endowment_data_filtered <- endowment_data %>%
 saveRDS(endowment_data_filtered, here("data", "endowment_filter_data_990.RDS"))
 ```
 
+```{r}
+
+read_csv(here('data', 'companies.csv')) %>%
+  mutate(EIN = as.character(ein)) %>%
+  select(organization_name, EIN, ein) %>%
+  distinct() %>%
+  write_csv(here('data', 'companies.csv'))
+
+
+```
+


### PR DESCRIPTION
I noticed that joining to `companies.csv` introduces additional rows to the data frame because some EINs correspond to multiple dance styles. I added this section in `load_wrangle_filter.Rmd` to resolve this. If we want to look at the dance information later we can include a modified csv in the data directory.

This will only affect a couple of rows, but will be important in some of the plots that count number of observations after joining to `companies.csv.` Rerunning those files after running the updated  `load_wrangle_filter.Rmd` will resolve this!